### PR TITLE
Fix Chart memory leaks by properly destroying instances

### DIFF
--- a/js/legacy-app.js
+++ b/js/legacy-app.js
@@ -1,3 +1,10 @@
+// Chart instance references for proper cleanup
+let retirementChart = null;
+const ssStrategyCharts = {};
+let taxSummaryChart = null;
+let incomeDetailsChart = null;
+let taxDetailsChart = null;
+
 // Get DOM elements
         const withdrawalRateSlider = document.getElementById('withdrawal-rate');
         const withdrawalRateValue = document.getElementById('withdrawal-rate-value');
@@ -415,7 +422,10 @@ function createRetirementChart(netWorth, annualExpenses, withdrawalRate, nominal
   
   // Create chart
   const ctx = canvas.getContext('2d');
-  const chart = new Chart(ctx, {
+  if (retirementChart) {
+    retirementChart.destroy();
+  }
+  retirementChart = new Chart(ctx, {
     type: 'bar',
     data: {
       labels: labels,
@@ -680,17 +690,6 @@ includeSpouse.addEventListener('change', () => {
     }
 });
 
-// Toggle all Social Security fields
-ssIncludeSelect.addEventListener('change', () => {
-    const containers = document.querySelectorAll('#ss-method-container, #ss-statement-fields, #ss-estimate-fields, .spouse-ss-section');
-    if (ssIncludeSelect.value === 'yes') {
-        containers.forEach(container => container.style.display = 'block');
-        // Make sure the correct estimation method is shown
-        ssMethodSelect.dispatchEvent(new Event('change'));
-    } else {
-        containers.forEach(container => container.style.display = 'none');
-    }
-});
 
 // UPDATED: Modified event listeners to update strategy chart when inputs change
 ssMonthlyBenefit.addEventListener('input', function() {
@@ -1016,7 +1015,10 @@ function createSSStrategyChart(fraBenefit, currentAge, currentNetWorth, annualEx
     
     // Create chart
     const ctx = canvas.getContext('2d');
-    new Chart(ctx, {
+    if (ssStrategyCharts[containerId]) {
+        ssStrategyCharts[containerId].destroy();
+    }
+    ssStrategyCharts[containerId] = new Chart(ctx, {
         type: 'bar',
         data: {
             labels: labels,
@@ -1098,7 +1100,7 @@ function createSSStrategyChart(fraBenefit, currentAge, currentNetWorth, annualEx
 const originalCalculateBtnHandler = calculateBtn.onclick;
 calculateBtn.onclick = function() {
     if (originalCalculateBtnHandler) {
-        originalCalculateBtnHandler.call.call(this);
+        originalCalculateBtnHandler.call(this);
     } else {
         // Otherwise, just run the default calculation code
     }
@@ -1443,7 +1445,8 @@ function createTaxBracketChart(incomeBreakdown, taxBreakdown, filingStatus) {
     
     // Create combo chart with income sources and tax brackets
     const ctx = canvas.getContext('2d');
-    new Chart(ctx, {
+    if (taxSummaryChart) taxSummaryChart.destroy();
+    taxSummaryChart = new Chart(ctx, {
         type: 'bar',
         data: {
             labels: ['Income Sources', 'Tax Brackets'],
@@ -1551,7 +1554,8 @@ function createTaxBracketChart(incomeBreakdown, taxBreakdown, filingStatus) {
     incomeDetailsContainer.appendChild(incomeDetailsCanvas);
     
     const incomeDetailsCtx = incomeDetailsCanvas.getContext('2d');
-    new Chart(incomeDetailsCtx, {
+    if (incomeDetailsChart) incomeDetailsChart.destroy();
+    incomeDetailsChart = new Chart(incomeDetailsCtx, {
         type: 'doughnut',
         data: {
             labels: incomeLabels,
@@ -1607,7 +1611,8 @@ function createTaxBracketChart(incomeBreakdown, taxBreakdown, filingStatus) {
     taxDetailsContainer.appendChild(taxDetailsCanvas);
     
     const taxDetailsCtx = taxDetailsCanvas.getContext('2d');
-    new Chart(taxDetailsCtx, {
+    if (taxDetailsChart) taxDetailsChart.destroy();
+    taxDetailsChart = new Chart(taxDetailsCtx, {
         type: 'pie',
         data: {
             labels: taxLabels,


### PR DESCRIPTION
## Summary
This PR fixes memory leaks in the chart rendering functions by properly destroying previous Chart instances before creating new ones. This prevents multiple chart instances from accumulating in memory when charts are re-rendered.

## Key Changes
- Added global chart instance references (`retirementChart`, `ssStrategyCharts`, `taxSummaryChart`, `incomeDetailsChart`, `taxDetailsChart`) at the top of the file for tracking active charts
- Modified `createRetirementChart()` to destroy the previous chart instance before creating a new one
- Modified `createSSStrategyChart()` to destroy previous strategy chart instances (stored in an object keyed by container ID) before creating new ones
- Modified `createTaxBracketChart()` to destroy previous instances of the tax summary, income details, and tax details charts before creating new ones
- Removed unused Social Security toggle event listener (`ssIncludeSelect.addEventListener('change')`)
- Fixed a typo in the calculate button handler: changed `originalCalculateBtnHandler.call.call(this)` to `originalCalculateBtnHandler.call(this)`

## Implementation Details
- Chart instances are now stored in module-level variables, allowing them to be referenced and destroyed when charts are recreated
- The Social Security strategy charts use an object map (`ssStrategyCharts`) to handle multiple chart instances (one per container)
- Each chart creation now follows the pattern: check if instance exists → destroy if it does → create and store new instance
- This ensures only one active Chart.js instance exists per chart type at any given time, preventing memory accumulation

https://claude.ai/code/session_01GHocC74aV7gWVvb1B2hose